### PR TITLE
Use a publicly accessible url for the submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "device_database"]
 	path = device_database
-	url = git://github.com/android-rooting-tools/android_device_database.git
+	url = https://github.com/android-rooting-tools/android_device_database.git
 [submodule "libkallsyms"]
 	path = libkallsyms
 	url = https://github.com/android-rooting-tools/libkallsyms.git


### PR DESCRIPTION
Outside contributors without `git://` access to the android_device_database repo get a fatal error when trying to clone the repo. Changing the access method to `https://` makes it possible for these user to clone the repo and all its submodules.